### PR TITLE
Fixup build errors

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc, Duration, Local, Datelike, Weekday, NaiveDate, NaiveDateTime};
+use chrono::{DateTime, Utc, Duration, Local, Datelike, Weekday, NaiveDate, NaiveDateTime, TimeZone};
 use serde::{Serialize, Deserialize};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter};
@@ -177,9 +177,9 @@ fn report_summary(time_sheet: &TimeSheet, period_name: &str) -> io::Result<()> {
         _ => return Err(io::Error::new(io::ErrorKind::InvalidInput, "Invalid summary period")),
     };
 
-    let tz_offset = *now_local.offset();
-    let start_interval_utc = DateTime::<Utc>::from_naive_utc_and_offset(start_naive, tz_offset).to_utc();
-    let end_interval_utc = DateTime::<Utc>::from_naive_utc_and_offset(end_naive, tz_offset).to_utc();
+    // Correctly convert the local NaiveDateTime to a UTC DateTime.
+    let start_interval_utc = Local.from_local_datetime(&start_naive).unwrap().to_utc();
+    let end_interval_utc = Local.from_local_datetime(&end_naive).unwrap().to_utc();
 
     let total_duration = calculate_tracked_time_in_interval(time_sheet, start_interval_utc, end_interval_utc);
     println!("Total time tracked for this {}: {}", period_name, format_duration(total_duration));


### PR DESCRIPTION
Prompt
------

Thanks! But I can't build that file. The Rust compiler reported errors:

```
   Compiling time_tracker v0.1.0 (/home/osteffen/time_tracker)
warning: unused imports: `NaiveDateTime` and `Weekday`
 --> src/main.rs:1:56
  |
1 | use chrono::{DateTime, Utc, Duration, Local, Datelike, Weekday,
NaiveDate, NaiveDateTime};
  |                                                        ^^^^^^^
^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

error[E0308]: mismatched types
   --> src/main.rs:181:86
    |
181 |     let start_interval_utc =
DateTime::<Utc>::from_naive_utc_and_offset(start_naive,
tz_offset).to_utc();
    |
------------------------------------------              ^^^^^^^^^
expected `Utc`, found `FixedOffset`
    |                              |
    |                              arguments to this function are
incorrect
    |
note: associated function defined here
   -->
/home/osteffen/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/chrono-0.4.41/src/datetime/mod.rs:94:18
    |
94  |     pub const fn from_naive_utc_and_offset(
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^

error[E0308]: mismatched types
   --> src/main.rs:182:82
    |
182 |     let end_interval_utc =
DateTime::<Utc>::from_naive_utc_and_offset(end_naive,
tz_offset).to_utc();
    |
------------------------------------------            ^^^^^^^^^ expected
`Utc`, found `FixedOffset`
    |                            |
    |                            arguments to this function are
incorrect
    |
note: associated function defined here
   -->
/home/osteffen/.cargo/registry/src/index.crates.io-1949cf8c6b5b557f/chrono-0.4.41/src/datetime/mod.rs:94:18
    |
94  |     pub const fn from_naive_utc_and_offset(
    |                  ^^^^^^^^^^^^^^^^^^^^^^^^^

For more information about this error, try `rustc --explain E0308`.
warning: `time_tracker` (bin "time_tracker") generated 1 warning
error: could not compile `time_tracker` (bin "time_tracker") due to 2
previous errors; 1 warning emitted

```

Can you fix it?

Response
--------

Of course. My apologies for the compilation errors. You are absolutely
right, there was a type mismatch in how the local timezone was being
handled. Thank you for providing the compiler output; that was very
helpful.

The issue was in converting the "naive" start and end times of the
reporting interval into UTC. I was using an incorrect chrono function.
I've corrected the logic to properly use the local timezone for the
conversion.

Here is the fixed version of the code.

I have made the following changes:

    Added TimeZone to the use chrono::{...} import line.
    Modified the two lines in report_summary to correctly convert the
naive local times to UTC-based DateTime objects.

This should resolve the compilation errors and make the reporting
features work as expected. Let me know if you run into any other issues!

## Summary by Sourcery

Fix build errors by correcting the conversion of naive LocalDateTime values to UTC using `Local.from_local_datetime` instead of the mismatched `from_naive_utc_and_offset` method.

Bug Fixes:
- Resolve build errors caused by incorrect chrono type mismatch when converting naive local times to UTC
- Remove unused tz_offset variable and replace `DateTime::<Utc>::from_naive_utc_and_offset` calls with `Local.from_local_datetime(...).unwrap().to_utc()`