### PR TITLE
Fixup: Remove unused imports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,4 +1,4 @@
-use chrono::{DateTime, Utc, Duration, Local, Datelike, Weekday, NaiveDate, NaiveDateTime, TimeZone};
+use chrono::{DateTime, Utc, Duration, Local, Datelike, NaiveDate, TimeZone};
 use serde::{Serialize, Deserialize};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter};


### PR DESCRIPTION
Prompt
------

Great! Now it works.

Cargo reported some unused imports that I then cleaned up in addition.
See:

```
warning: unused imports: `NaiveDateTime` and `Weekday`
 --> src/main.rs:1:56
  |
1 | use chrono::{DateTime, Utc, Duration, Local, Datelike, Weekday,
NaiveDate, NaiveDateTime, TimeZone};
  |                                                        ^^^^^^^
^^^^^^^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: `time_tracker` (bin "time_tracker") generated 1 warning (run
`cargo fix --bin "time_tracker"` to apply 1 suggestion)

```

Response
--------

Thank you for pointing out the compiler warnings. You are absolutely
right; keeping the code clean of warnings is best practice. I appreciate
you catching that!

I've updated the code to remove those unused imports, incorporating your
feedback.

I've removed Weekday and NaiveDateTime from the import list at the top
of the file. The code remains functionally identical but should now
compile without any warnings.

Let me know if there's anything else you'd like to do!

## Summary by Sourcery

Bug Fixes:
- Remove unused chrono imports Weekday and NaiveDateTime from main.rs to eliminate compiler warnings