### PR TITLE
Fixup: Remove unused imports

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -1,11 +1,10 @@
-use chrono::{DateTime, Utc, Duration, Local, Datelike, NaiveDate, TimeZone, Weekday};
+use chrono::{DateTime, Utc, Duration, Local, Datelike, NaiveDate, TimeZone};
 use serde::{Serialize, Deserialize};
 use std::fs::{File, OpenOptions};
 use std::io::{self, BufReader, BufWriter};
 use std::env;
 use std::path::PathBuf;
 use std::cmp;
-use std::iter::Sum;
 
 // Represents a single time period with a start and end time.
 // Added Clone and Copy to make it easier to pass around.


### PR DESCRIPTION
Prompt
------

It seems you added some unused imports. See this compiler output:

```
$ cargo build
   Compiling time_tracker v0.1.0 (/home/osteffen/time_tracker)
warning: unused import: `Weekday`
 --> src/main.rs:1:77
  |
1 | use chrono::{DateTime, Utc, Duration, Local, Datelike, NaiveDate,
TimeZone, Weekday};
  |
^^^^^^^
  |
  = note: `#[warn(unused_imports)]` on by default

warning: unused import: `std::iter::Sum`
 --> src/main.rs:8:5
  |
8 | use std::iter::Sum;
  |     ^^^^^^^^^^^^^^

warning: `time_tracker` (bin "time_tracker") generated 2 warnings (run
`cargo fix --bin "time_tracker"` to apply 1 suggestion)

```

Response
--------

You are absolutely right! My apologies, I missed cleaning those up
during the refactoring. Thank you for catching them and providing the
compiler output. It's always best to have warning-free code.

I have now removed the unused imports from the code.

## Summary by Sourcery

Remove unused imports to eliminate compiler warnings

Chores:
- Remove unused Weekday import from chrono in main.rs
- Remove unused Sum import from std::iter in main.rs