### PR TITLE
Fix readme and some refactoring

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,85 @@
-Work Time TrackerA simple command-line utility written in Rust to track work time.DescriptionThis utility allows you to track time periods by recording start and stop times. It is designed to be simple and robust, ensuring that only one time period can be actively tracked at any given moment. The data is stored in a local file to persist between commands.FeaturesStart Tracking: Begin a new work period.Stop Tracking: End the current work period.Idempotent Operations: Running start or stop multiple times in a row will not create duplicate entries or errors.Data Persistence: Time entries are stored in a timesheet.json file in your home directory.Status Display: Shows the current tracking status and calculates the duration of the last session.UsagePrerequisitesYou need to have Rust and Cargo installed on your system. If you don't have them, you can install them from rustup.rs.Building the ProjectClone this repository or download the source code.Navigate to the project directory.Build the project using Cargo:cargo build --release
-The executable will be located at target/release/work_time_tracker. You can add this to your system's PATH for easier access.CommandsThere are two main commands:1. Start a new tracking periodwork_time_tracker start
-This command will:Check if a period is already being tracked.If not, it records the current timestamp as the start time.If a period is already active, it will inform you and do nothing.2. Stop the current tracking periodwork_time_tracker stop
-This command will:Check if a period is currently being tracked.If yes, it records the current timestamp as the stop time and calculates the duration.If no period is active, it will inform you and do nothing.Data StorageThe application stores its data in a JSON file named .work_time_tracker.json located in your user's home directory (e.g., /home/user/.work_time_tracker.json).The JSON file has the following structure:{
+# Work Time Tracker
+
+A simple command-line utility written in Rust to track work time.
+
+## Description
+
+This utility allows you to track time periods by recording start and stop times. It is designed to be simple and robust, ensuring that only one time period can be actively tracked at any given moment. The data is stored in a local file to persist between commands. You can also generate reports for tracked time for the current day, week, or month.
+
+## Features
+
+* **Start Tracking**: Begin a new work period.
+* **Stop Tracking**: End the current work period.
+* **Idempotent Operations**: Running `start` or `stop` multiple times in a row will not create duplicate entries or errors.
+* **Data Persistence**: Time entries are stored in a `.work_time_tracker.json` file in your home directory.
+* **Time Reporting**: Get summaries of tracked time for the current day, week, or month.
+
+## Usage
+
+### Prerequisites
+
+You need to have Rust and Cargo installed on your system. If you don't have them, you can install them from [rustup.rs](https://rustup.rs/).
+
+### Building the Project
+
+1. Clone this repository or download the source code.
+2. Navigate to the project directory.
+3. Build the project using Cargo:
+   ```bash
+   cargo build --release
+   ```
+4. The executable will be located at `target/release/work_time_tracker`. You can add this to your system's PATH for easier access.
+
+### Commands
+
+#### 1. Start a new tracking period
+
+```bash
+work_time_tracker start
+```
+
+This command will:
+* Check if a period is already being tracked.
+* If not, it records the current timestamp as the start time.
+* If a period is already active, it will inform you and do nothing.
+
+#### 2. Stop the current tracking period
+
+```bash
+work_time_tracker stop
+```
+
+This command will:
+* Check if a period is currently being tracked.
+* If yes, it records the current timestamp as the stop time and calculates the duration.
+* If no period is active, it will inform you and do nothing.
+
+#### 3. Report Tracked Time
+
+You can get a summary of tracked time over different periods. These commands are read-only and will not modify your data file. They include any currently active session in the calculation.
+
+-   **For the current day:**
+    ```bash
+    work_time_tracker today
+    ```
+
+-   **For the current week (Monday to Sunday):**
+    ```bash
+    work_time_tracker week
+    ```
+
+-   **For the current month:**
+    ```bash
+    work_time_tracker month
+    ```
+
+## Data Storage
+
+The application stores its data in a JSON file named `.work_time_tracker.json` located in your user's home directory (e.g., `/home/user/.work_time_tracker.json`).
+
+The JSON file has the following structure:
+```json
+{
   "periods": [
     {
       "start": "2023-10-27T10:00:00Z",
@@ -10,4 +88,8 @@ This command will:Check if a period is currently being tracked.If yes, it record
   ],
   "active_period_start": "2023-10-27T19:00:00Z"
 }
-periods: An array of completed time periods.active_period_start: The start time of the currently active period. If no period is active, this will be null.
+```
+
+- `periods`: An array of completed time periods.
+- `active_period_start`: The start time of the currently active period. If no period is active, this will be `null`.
+


### PR DESCRIPTION
- **README: fix formatting**
- **Refactoring: Use enum for reporting period**

## Summary by Sourcery

Improve documentation and refactor reporting logic for robust period handling and timezone conversions

Enhancements:
- Replace string-based report commands with a ReportingPeriod enum for compile-time safety
- Add a naive_to_utc helper to handle ambiguous or invalid local times
- Refactor period generation functions to return Result<Period> and use naive_to_utc for error handling

Documentation:
- Revamp README formatting with proper markdown and add detailed usage instructions for time reporting commands